### PR TITLE
ci: avoid optional liquidSVM in coverage deps

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -24,7 +24,8 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr, any::xml2
+          extra-packages: any::covr, any::xml2, any::testthat
+          dependencies: '"hard"'
           needs: coverage
 
       - name: Test coverage


### PR DESCRIPTION
Fixes #10.

## Summary
- keep the coverage workflow from trying to install every optional `Suggests` package
- explicitly install `testthat` for the coverage test runner
- leave package code/tests unchanged

The current `test-coverage.yaml` run fails before tests start during `setup-r-dependencies`, because pak tries to solve optional `Suggests` and cannot find `liquidSVM`:

```text
* deps::.: Can't install dependency liquidSVM
* liquidSVM: Can't find package called liquidSVM.
```

`liquidSVM` is documented as optional in the README and the package already has fallback behavior for non-`liquidSVM` methods, so the CI dependency install should avoid requiring it just to run coverage.

## Verification
- `git diff --check` ✅
- Inspected the latest failing Actions log for run `24883441814`; failure is in `r-lib/actions/setup-r-dependencies@v2` before coverage/tests execute.
- Local R verification not run in this worker because `R` is not installed here.

## Safety
Workflow-only change. No secrets, deployments, external services, or package runtime behavior changed.
